### PR TITLE
AsyncImage improvements

### DIFF
--- a/Examples/UIComponentExample/Examples/AsyncImage/AsyncImage.swift
+++ b/Examples/UIComponentExample/Examples/AsyncImage/AsyncImage.swift
@@ -1,35 +1,42 @@
 //  Created by Luke Zhao on 6/14/21.
 
-import UIComponent
 import UIKit
 import Kingfisher
+import UIComponent
 
 public struct AsyncImage: ViewComponentBuilder {
-  public let url: URL
-  public let indicatorType: IndicatorType
-  public let options: KingfisherOptionsInfo?
   
-  public init(_ url: URL,
-              indicatorType: IndicatorType = .none,
-              options: KingfisherOptionsInfo? = nil) {
+  public typealias AsyncIndicatorType = IndicatorType
+  public typealias ConfigurationBuilder = (KF.Builder) -> KF.Builder
+  
+  public let url: URL?
+  public let indicatorType: AsyncIndicatorType
+  public let configurationBuilder: ConfigurationBuilder?
+  
+  public init(_ url: URL?,
+              indicatorType: AsyncIndicatorType = .none,
+              configurationBuilder: ConfigurationBuilder? = nil) {
     self.url = url
     self.indicatorType = indicatorType
-    self.options = options
+    self.configurationBuilder = configurationBuilder
   }
   
-  public init?(_ urlString: String,
-               indicatorType: IndicatorType = .none,
-               options: KingfisherOptionsInfo? = nil) {
-    guard let url = URL(string: urlString) else { return nil }
-    self.url = url
+  public init(_ urlString: String,
+               indicatorType: AsyncIndicatorType = .none,
+               configurationBuilder: ConfigurationBuilder? = nil) {
+    self.url = URL(string: urlString)
     self.indicatorType = indicatorType
-    self.options = options
+    self.configurationBuilder = configurationBuilder
   }
   
   public func build() -> ViewUpdateComponent<SimpleViewComponent<UIImageView>> {
     SimpleViewComponent<UIImageView>().update {
       $0.kf.indicatorType = indicatorType
-      $0.kf.setImage(with: url, options: options)
+      if let configurationBuilder = configurationBuilder {
+        configurationBuilder(KF.url(url)).set(to: $0)
+      } else {
+        KF.url(url).set(to: $0)
+      }
     }
   }
 }

--- a/Examples/UIComponentExample/Examples/Complex layout/Components/UserProfile.swift
+++ b/Examples/UIComponentExample/Examples/Complex layout/Components/UserProfile.swift
@@ -23,7 +23,7 @@ struct UserProfile: ComponentBuilder {
   
   func build() -> Component {
     HStack(spacing: 10, alignItems: .center) {
-      AsyncImage(avatar)!
+      AsyncImage(avatar)
         .contentMode(.scaleAspectFill)
         .clipsToBounds(true)
         .size(width: 64, height: 64)

--- a/Examples/UIComponentExample/Examples/Gallery Example/Components/GalleryComponents.swift
+++ b/Examples/UIComponentExample/Examples/Gallery Example/Components/GalleryComponents.swift
@@ -11,7 +11,7 @@ struct GalleryItemData: Equatable {
 struct GalleryItem: ComponentBuilder {
   let data: GalleryItemData
   func build() -> Component {
-    AsyncImage(data.cover, indicatorType: .activity, options: [.transition(.flipFromBottom(0.35))])
+    AsyncImage(data.cover, indicatorType: .activity, configurationBuilder: { $0.transition(.flipFromBottom(0.35)) })
       .contentMode(.scaleAspectFill)
       .clipsToBounds(true)
       .id(data.id)


### PR DESCRIPTION
before
```swift
AsyncImage2(object["avater"].stringValue, indicatorType: .activity, options: [.transition(.fade(0.25)), .processor((ResizingImageProcessor(referenceSize: CGSize(width: 30, height: 30).applying(.init(scaleX: screen.scale, y: screen.scale)), mode: .aspectFill)) |> RoundCornerImageProcessor(radius: .heightFraction(0.5)))]).size(width: 30, height: 30)
```

I think this way is better
```swift
AsyncImage(object["avater"].stringValue, indicatorType: .activity, configurationBuilder: {
  $0.fade(duration: 0.25)
    .resizing(referenceSize: CGSize(width: 30, height: 30).applying(.init(scaleX: screen.scale, y: screen.scale)), mode: .aspectFill)
    .roundCorner(radius: .heightFraction(0.5))
}).size(width: 30, height: 30)
```