### PR TITLE
Improvement `AsyncImage`

### DIFF
--- a/Examples/UIComponentExample/Examples/AsyncImage/AsyncImage.swift
+++ b/Examples/UIComponentExample/Examples/AsyncImage/AsyncImage.swift
@@ -5,30 +5,61 @@ import UIComponent
 import UIKit
 
 public struct AsyncImage: ViewComponentBuilder {
+  public enum SourceType {
+    // MARK: Member Cases
+
+    /// The target image should be got from network remotely. The associated `Resource`
+    /// value defines detail information like image URL and cache key.
+    case network(Kingfisher.Resource?)
+
+    /// The target image should be provided in a data format. Normally, it can be an image
+    /// from local storage or in any other encoding format (like Base64).
+    case provider(Kingfisher.ImageDataProvider)
+  }
 
   public typealias AsyncIndicatorType = IndicatorType
   public typealias ConfigurationBuilder = (KF.Builder) -> KF.Builder
 
-  public let url: URL?
+  public let source: SourceType
   public let indicatorType: AsyncIndicatorType
   public let configurationBuilder: ConfigurationBuilder?
 
   public init(
-    _ url: URL?,
-    indicatorType: AsyncIndicatorType = .none,
+    _ source: SourceType,
+    indicatorType: AsyncIndicatorType = .activity,
     configurationBuilder: ConfigurationBuilder? = nil
   ) {
-    self.url = url
+    self.source = source
+    self.indicatorType = indicatorType
+    self.configurationBuilder = configurationBuilder
+  }
+
+  public init(
+    _ url: URL?,
+    indicatorType: AsyncIndicatorType = .activity,
+    configurationBuilder: ConfigurationBuilder? = nil
+  ) {
+    self.source = .network(url)
     self.indicatorType = indicatorType
     self.configurationBuilder = configurationBuilder
   }
 
   public init(
     _ urlString: String,
-    indicatorType: AsyncIndicatorType = .none,
+    indicatorType: AsyncIndicatorType = .activity,
     configurationBuilder: ConfigurationBuilder? = nil
   ) {
-    self.url = URL(string: urlString)
+    self.source = .network(URL(string: urlString))
+    self.indicatorType = indicatorType
+    self.configurationBuilder = configurationBuilder
+  }
+
+  public init(
+    _ provider: ImageDataProvider,
+    indicatorType: AsyncIndicatorType = .activity,
+    configurationBuilder: ConfigurationBuilder? = nil
+  ) {
+    self.source = .provider(provider)
     self.indicatorType = indicatorType
     self.configurationBuilder = configurationBuilder
   }
@@ -38,9 +69,19 @@ public struct AsyncImage: ViewComponentBuilder {
       .update {
         $0.kf.indicatorType = indicatorType
         if let configurationBuilder = configurationBuilder {
-          configurationBuilder(KF.url(url)).set(to: $0)
+          switch source {
+          case .provider(let provider):
+            configurationBuilder(KF.dataProvider(provider)).set(to: $0)
+          case .network(let url):
+            configurationBuilder(KF.resource(url)).set(to: $0)
+          }
         } else {
-          KF.url(url).set(to: $0)
+          switch source {
+          case .provider(let provider):
+            KF.dataProvider(provider).set(to: $0)
+          case .network(let url):
+            KF.resource(url).set(to: $0)
+          }
         }
       }
   }


### PR DESCRIPTION
Support `ImageDataProvider`
e.g 
`AsyncImage(.provider(AVAssetImageDataProvider(assetURL: url, seconds: 0)))`
`AsyncImage(.network("..."))`