### PR TITLE
Use @_implementationOnly import BaseToolbox

### DIFF
--- a/Examples/UIComponentExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/UIComponentExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/lkzhao/BaseToolbox",
         "state": {
           "branch": null,
-          "revision": "0ce57936b566abb743c6a253aa267a36662cde97",
-          "version": "0.1.10"
+          "revision": "2962cea0ff0725629c0c90cddca1398faf2f807a",
+          "version": "0.1.14"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/lkzhao/BaseToolbox",
         "state": {
           "branch": null,
-          "revision": "0ce57936b566abb743c6a253aa267a36662cde97",
-          "version": "0.1.10"
+          "revision": "2962cea0ff0725629c0c90cddca1398faf2f807a",
+          "version": "0.1.14"
         }
       }
     ]

--- a/Sources/UIComponent/Components/Layout/Flex/FlexLayout.swift
+++ b/Sources/UIComponent/Components/Layout/Flex/FlexLayout.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/24/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 /// Implementation for `FlexColumn` & `FlexRow`

--- a/Sources/UIComponent/Components/Layout/Inset/Insets.swift
+++ b/Sources/UIComponent/Components/Layout/Inset/Insets.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/23/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 public struct Insets: Component {

--- a/Sources/UIComponent/Components/Layout/Other/Badge.swift
+++ b/Sources/UIComponent/Components/Layout/Other/Badge.swift
@@ -1,6 +1,6 @@
 //  Created by y H on 2021/7/25.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 /// # Badge Component

--- a/Sources/UIComponent/Components/Layout/Stack/StackRenderNode.swift
+++ b/Sources/UIComponent/Components/Layout/Stack/StackRenderNode.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/22/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 public protocol StackRenderNode: RenderNode, BaseLayoutProtocol {

--- a/Sources/UIComponent/Components/Layout/Stack/ZStack.swift
+++ b/Sources/UIComponent/Components/Layout/Stack/ZStack.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/26/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 public struct ZStack: Component {

--- a/Sources/UIComponent/Components/View/TappableView.swift
+++ b/Sources/UIComponent/Components/View/TappableView.swift
@@ -1,7 +1,7 @@
 //  Created by Luke Zhao on 6/8/21.
 
 import UIKit
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 
 public struct TappableViewConfiguration {
     public static var `default` = TappableViewConfiguration(onHighlightChanged: nil, didTap: nil)

--- a/Sources/UIComponent/Core/ComponentView/ComponentEngine.swift
+++ b/Sources/UIComponent/Core/ComponentView/ComponentEngine.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/27/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 public protocol ComponentReloadDelegate: AnyObject {

--- a/Sources/UIComponent/Core/Model/Animator.swift
+++ b/Sources/UIComponent/Core/Model/Animator.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 2017-07-19.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 open class Animator {

--- a/Sources/UIComponent/Core/Model/Constraint.swift
+++ b/Sources/UIComponent/Core/Model/Constraint.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/22/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 public struct Constraint {
@@ -8,7 +8,7 @@ public struct Constraint {
     public var maxSize: CGSize
     public var isTight: Bool { minSize == maxSize }
 
-    public init(minSize: CGSize = -.infinity, maxSize: CGSize = .infinity) {
+    public init(minSize: CGSize = .minSize, maxSize: CGSize = .infinity) {
         self.minSize = minSize
         self.maxSize = maxSize
     }

--- a/Sources/UIComponent/Core/Model/RenderNode/RenderNode.swift
+++ b/Sources/UIComponent/Core/Model/RenderNode/RenderNode.swift
@@ -1,6 +1,6 @@
 //  Created by Luke Zhao on 8/22/20.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import CoreGraphics
 import Foundation
 import UIKit

--- a/Sources/UIComponent/Extensions/CGSize.swift
+++ b/Sources/UIComponent/Extensions/CGSize.swift
@@ -1,7 +1,9 @@
 //  Created by Luke Zhao on 10/17/21.
 
+@_implementationOnly import BaseToolbox
 import CoreGraphics
 
 extension CGSize {
     public static let infinity: CGSize = CGSize(width: CGFloat.infinity, height: CGFloat.infinity)
+    public static let minSize: CGSize = -.infinity
 }

--- a/Sources/UIComponent/Extensions/UIScrollView+UIComponent.swift
+++ b/Sources/UIComponent/Extensions/UIScrollView+UIComponent.swift
@@ -1,6 +1,6 @@
 //  Created by Luke on 4/16/17.
 
-import BaseToolbox
+@_implementationOnly import BaseToolbox
 import UIKit
 
 extension UIScrollView {


### PR DESCRIPTION
My project also uses some of the same extension names and libraries (such as Then) as your "BaseToolbox". Direct import will lead to indirect extension of "BaseToolbox" in my project.