### PR TITLE
Fix issue laying out attributed strings with custom lineHeightMultiple

### DIFF
--- a/Sources/UIComponent/Components/View/Text.swift
+++ b/Sources/UIComponent/Components/View/Text.swift
@@ -77,7 +77,7 @@ public struct Text: ViewComponent {
         } else {
             // Faster route
             let size = attributedString.boundingRect(with: constraint.maxSize,
-                                                     options: [.usesLineFragmentOrigin],
+                                                     options: [.usesLineFragmentOrigin, .usesFontLeading],
                                                      context: nil).size
             return TextRenderNode(
                 attributedString: attributedString,


### PR DESCRIPTION
If you have an attributed string with a custom font and lineHeightMultiple, the layout will clip the text.

```swift
NSAttributedString("Are you sure?", attributes: [
    .font: UIFont.appFont(ofSize: 14, weight: .regular),
    .paragraphStyle: NSMutableParagraphStyle().then {
        $0.lineHeightMultiple = 0.8
    }
])
```

## Before
![FB8E376C-97C2-45D5-9431-332E320A72C6_4_5005_c](https://github.com/lkzhao/UIComponent/assets/13568/70f136c2-06c8-4a51-a7ad-d67a0e2e0d9b)

## After
![3BA8D746-0933-4C4A-89D9-91D8FD5EEB36_4_5005_c](https://github.com/lkzhao/UIComponent/assets/13568/a89cc477-84c7-4d7f-9765-40a393ee3b59)
