### PR TITLE
Fix typo (`ComponentViewManager` → `ComponentViewManager`)

### DIFF
--- a/Sources/UIComponent/Core/ComponentView/ComponentEngine.swift
+++ b/Sources/UIComponent/Core/ComponentView/ComponentEngine.swift
@@ -190,7 +190,7 @@ public class ComponentEngine {
             isRendering = false
         }
 
-        ComponentViewMananger.shared.push(view: componentView)
+        ComponentViewManager.shared.push(view: componentView)
         let renderNode: any RenderNode
         if let currentRenderNode = self.renderNode {
             renderNode = currentRenderNode
@@ -210,7 +210,7 @@ public class ComponentEngine {
         let visibleFrame = (contentView?.convert(bounds, from: view) ?? bounds).inset(by: visibleFrameInsets)
 
         var newVisibleRenderable = renderNode.visibleRenderables(in: visibleFrame)
-        ComponentViewMananger.shared.pop()
+        ComponentViewManager.shared.pop()
         if contentSize != renderNode.size * zoomScale {
             // update contentSize if it is changed. Some renderNodes update
             // its size when visibleRenderables(in: visibleFrame) is called. e.g. InfiniteLayout

--- a/Sources/UIComponent/Core/ComponentView/ComponentViewManager.swift
+++ b/Sources/UIComponent/Core/ComponentView/ComponentViewManager.swift
@@ -2,8 +2,8 @@
 
 import Foundation
 
-internal class ComponentViewMananger {
-    static let shared = ComponentViewMananger()
+internal class ComponentViewManager {
+    static let shared = ComponentViewManager()
     
     private var stack: [ComponentDisplayableView] = []
     
@@ -21,7 +21,7 @@ internal class ComponentViewMananger {
 }
 
 public func currentComponentView() -> ComponentDisplayableView? {
-    ComponentViewMananger.shared.last
+    ComponentViewManager.shared.last
 }
 
 extension Component {


### PR DESCRIPTION
Hi, I was looking through the code and found a typo, so I'm fixing it.