### PR TITLE
fix reuse strategy not honored on Any render node

### DIFF
--- a/Sources/UIComponent/Core/Model/RenderNode/AnyRenderNode.swift
+++ b/Sources/UIComponent/Core/Model/RenderNode/AnyRenderNode.swift
@@ -44,7 +44,7 @@ public struct AnyRenderNode: RenderNode {
         erasing._updateView(view)
     }
     public func makeView() -> UIView {
-        erasing._makeView()
+        erasing.makeView()
     }
 }
 
@@ -90,6 +90,6 @@ public struct AnyRenderNodeOfView<View: UIView>: RenderNode {
         erasing._updateView(view)
     }
     public func makeView() -> View {
-        erasing._makeView() as! View
+        erasing.makeView() as! View
     }
 }

--- a/Tests/UIComponentTests/ReuseTest.swift
+++ b/Tests/UIComponentTests/ReuseTest.swift
@@ -74,6 +74,46 @@ final class ReuseTests: XCTestCase {
         XCTAssertNotEqual(existingLabel, newLabel)
     }
 
+    func testNoReuseWhenNoReuseStrategyWithAnyComponentOfView() {
+        componentView.component = Text("1").eraseToAnyComponentOfView().reuseStrategy(.noReuse)
+        componentView.reloadData()
+        XCTAssertEqual(componentView.subviews.count, 1)
+        let existingLabel = componentView.subviews.first as? UILabel
+        XCTAssertNotNil(existingLabel)
+        XCTAssertEqual(existingLabel?.text, "1")
+        componentView.component = VStack {
+            Text("2").eraseToAnyComponentOfView().reuseStrategy(.noReuse)
+        }
+        componentView.reloadData()
+        XCTAssertEqual(componentView.subviews.count, 1)
+        let newLabel = componentView.subviews.first as? UILabel
+        XCTAssertNotNil(newLabel)
+        XCTAssertEqual(newLabel?.text, "2")
+
+        // the UILabel should not be reused
+        XCTAssertNotEqual(existingLabel, newLabel)
+    }
+
+    func testNoReuseWhenNoReuseStrategyWithAnyComponent() {
+        componentView.component = Text("1").eraseToAnyComponent().reuseStrategy(.noReuse)
+        componentView.reloadData()
+        XCTAssertEqual(componentView.subviews.count, 1)
+        let existingLabel = componentView.subviews.first as? UILabel
+        XCTAssertNotNil(existingLabel)
+        XCTAssertEqual(existingLabel?.text, "1")
+        componentView.component = VStack {
+            Text("2").eraseToAnyComponent().reuseStrategy(.noReuse)
+        }
+        componentView.reloadData()
+        XCTAssertEqual(componentView.subviews.count, 1)
+        let newLabel = componentView.subviews.first as? UILabel
+        XCTAssertNotNil(newLabel)
+        XCTAssertEqual(newLabel?.text, "2")
+
+        // the UILabel should not be reused
+        XCTAssertNotEqual(existingLabel, newLabel)
+    }
+
     func testReuseWithSameAttributes() {
         componentView.component = Text("1").backgroundColor(.red)
         componentView.reloadData()


### PR DESCRIPTION
Reason because it is calling the internal `_makeView()` method which checks for the reuse strategy again for the erasing render node which is not being overridden.