### PR TITLE
Fix incorrect parameter in `didMove(toParent:)` call

### DIFF
--- a/Sources/UIComponent/Components/View/SwiftUI.swift
+++ b/Sources/UIComponent/Components/View/SwiftUI.swift
@@ -62,7 +62,7 @@ class SwiftUIHostingView: UIView {
         hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         parentViewController.addChild(hostingController)
         addSubview(hostingController.view)
-        hostingController.didMove(toParent: nil)
+        hostingController.didMove(toParent: parentViewController)
     }
 
     override func layoutSubviews() {


### PR DESCRIPTION
### Summary

This PR fixes an incorrect usage of `didMove(toParent:)` when adding a `UIHostingController` as a child view controller. The method was previously called with `nil`, which is only appropriate when *removing* a child view controller.

### Details

According to the UIKit view controller containment API, after calling `addChild(_:)`, you must call `didMove(toParent:)` with the new parent view controller as the argument. Passing `nil` in this context is incorrect and may cause lifecycle inconsistencies.
