### PR TITLE
Add environment-based foreground color support

### DIFF
--- a/Examples/UIComponentExample.xcodeproj/project.pbxproj
+++ b/Examples/UIComponentExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -85,6 +85,10 @@
 		F8E3DD1726A7BE300062E58F /* Modifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Modifiers.swift; sourceTree = "<group>"; };
 		F8E3DD1926A7BEB60062E58F /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		6A6204B92E0BD68400B01E4D /* Environment Example */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Environment Example"; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A304892121C347010026EDA7 /* Frameworks */ = {
@@ -192,6 +196,7 @@
 		B1CC3F6C267800B9005BCE8C /* Examples */ = {
 			isa = PBXGroup;
 			children = (
+				6A6204B92E0BD68400B01E4D /* Environment Example */,
 				B11955B62DD297A80074305F /* SwiftUI */,
 				B1CC3F6A2678009C005BCE8C /* AsyncImage */,
 				B1CC3F692678008F005BCE8C /* Card */,
@@ -265,6 +270,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				6A6204B92E0BD68400B01E4D /* Environment Example */,
 			);
 			name = UIComponentExample;
 			packageProductDependencies = (

--- a/Examples/UIComponentExample/Examples/Environment Example/EnvironmentExampleViewController.swift
+++ b/Examples/UIComponentExample/Examples/Environment Example/EnvironmentExampleViewController.swift
@@ -1,0 +1,50 @@
+//  Created by y H on 2025/6/25.
+
+import UIKit
+import UIComponent
+
+class EnvironmentExampleViewController: ComponentViewController {
+    override var component: any Component {
+        VStack(spacing: 10, alignItems: .stretch) {
+            Text("Used")
+            Label("Share", systemImage: "square.and.arrow.up.fill")
+                .minSize(height: 44)
+                .centered()
+                .backgroundColor(.systemBlue)
+                .roundedCorner()
+            Label("Remove", systemImage: "trash.fill")
+                .minSize(height: 44)
+                .centered()
+                .backgroundColor(.systemRed)
+                .roundedCorner()
+            let fontSizes: [CGFloat] = [12,14,16,18,20,22,24,26,28,30]
+            VStack(spacing: 10) {
+                HStack(spacing: 5) {
+                    let fonts: [UIFont] = fontSizes.map { .systemFont(ofSize: $0, weight: .thin) }
+                    for font in fonts {
+                        Image(systemName: "alarm")
+                            .font(font)
+                    }
+                }
+                HStack(spacing: 5) {
+                    let fonts: [UIFont] = fontSizes.map { .systemFont(ofSize: $0, weight: .regular) }
+                    for font in fonts {
+                        Image(systemName: "alarm")
+                            .font(font)
+                    }
+                }
+                HStack(spacing: 5) {
+                    let fonts: [UIFont] = fontSizes.map { .systemFont(ofSize: $0, weight: .semibold) }
+                    for font in fonts {
+                        Image(systemName: "alarm")
+                            .font(font)
+                    }
+                }
+            }
+            .foregroundColor(.systemIndigo)
+        }
+        .foregroundColor(.white)
+        .font(.systemFont(ofSize: 16, weight: .semibold))
+        .inset(20)
+    }
+}

--- a/Examples/UIComponentExample/Examples/Environment Example/Label.swift
+++ b/Examples/UIComponentExample/Examples/Environment Example/Label.swift
@@ -1,0 +1,90 @@
+//  Created by y H on 2025/6/25.
+//  Copyright © 2025 wwdc14yh. All rights reserved.
+
+import UIKit
+import UIComponent
+
+public protocol LabelStyle {
+    typealias Configuration = Label.StyleConfiguration
+    associatedtype C: Component
+
+    @MainActor @preconcurrency
+    func makeBody(configuration: Self.Configuration) -> Self.C
+}
+
+public struct DefaultLabelStyle: LabelStyle {
+    public func makeBody(configuration: Configuration) -> some Component {
+        HStack(spacing: 5, alignItems: .center) {
+            configuration.icon
+            configuration.title
+        }
+    }
+}
+
+public extension LabelStyle where Self == DefaultLabelStyle {
+    static var automatic: DefaultLabelStyle {
+        DefaultLabelStyle()
+    }
+}
+
+public extension Label {
+    struct StyleConfiguration {
+        public let title: any Component
+        public let icon: any Component
+    }
+}
+
+public struct LabelStyleEnvironmentKey: EnvironmentKey {
+    public static var defaultValue: any LabelStyle { .automatic }
+}
+
+public extension EnvironmentValues {
+    var labelStyle: any LabelStyle {
+        get {
+            self[LabelStyleEnvironmentKey.self]
+        } set {
+            self[LabelStyleEnvironmentKey.self] = newValue
+        }
+    }
+}
+
+public extension Component {
+    func labelStyle(_ style: any LabelStyle) -> EnvironmentComponent<any LabelStyle, Self> {
+        environment(\.labelStyle, value: style)
+    }
+}
+
+public struct Label: ComponentBuilder {
+    @Environment(\.labelStyle)
+    var labelStyle
+
+    let title: any Component
+    let icon: any Component
+
+    public init(title: () -> any Component, icon: () -> any Component) {
+        self.title = title()
+        self.icon = icon()
+    }
+
+    public init(_ titleString: String, systemImage name: String) {
+        self.init {
+            Text(titleString)
+        } icon: {
+            Image(systemName: name)
+        }
+    }
+
+    public init(_ titleString: String, image name: String) {
+        self.init {
+            Text(titleString)
+        } icon: {
+            Image(name)
+        }
+    }
+
+    public func build() -> some Component {
+        labelStyle.makeBody(configuration: StyleConfiguration(title: title,
+                                                              icon: icon))
+            .eraseToAnyComponent()
+    }
+}

--- a/Examples/UIComponentExample/ViewController.swift
+++ b/Examples/UIComponentExample/ViewController.swift
@@ -17,11 +17,14 @@ class ViewController: ComponentViewController {
                 ExampleItem(name: "Complex Example", viewController: ComplexLayoutViewController())
                 ExampleItem(name: "Custom Layout Example", viewController: GalleryViewController())
                 ExampleItem(name: "Size Example", viewController: SizeExampleViewController())
+                ExampleItem(name: "Environment Example", viewController: EnvironmentExampleViewController())
                 ExampleItem(name: "SwiftUI Example", viewController: SwiftUIExampleViewController())
             } separator: {
                 Separator()
             }
-        }.viewController(self)
+        }
+        .foregroundColor(.systemBlue)
+        .viewController(self)
     }
 }
 

--- a/Sources/UIComponent/Components/View/Image.swift
+++ b/Sources/UIComponent/Components/View/Image.swift
@@ -4,14 +4,56 @@ import UIKit
 
 /// An image component that renders an UIImageView
 public struct Image: Component {
+    enum Source {
+        case custom(UIImage)
+        case systemImage(systemName: String, configuration: UIImage.Configuration?)
+
+        func getImage(_ font: UIFont) -> UIImage {
+            switch self {
+            case let .custom(uIImage):
+                return uIImage
+            case let .systemImage(systemName, configuration):
+                let configuration =
+                    if let configuration {
+                        configuration.applying(UIImage.SymbolConfiguration(font: font))
+                    } else {
+                        UIImage.SymbolConfiguration(font: font)
+                    }
+                var uIImage: UIImage {
+                    #if DEBUG
+                    if let systemImage = UIImage(systemName: systemName, withConfiguration: configuration) {
+                        return systemImage
+                    } else {
+                        let error = "Image should be initialized with a valid system image name. System image named \(systemName) not found."
+                        fatalError(error)
+                    }
+                    #else
+                    return UIImage(systemName: systemName, withConfiguration: configuration) ?? UIImage()
+                    #endif
+                }
+                return uIImage
+            }
+        }
+    }
+
+    /// The foreground color to use when displaying this image tint color
+    @Environment(\.foregroundColor) var foregroundColor
+
+    /// The font to use when displaying this systemImage font
+    @Environment(\.font) var font
+
     /// The underlying `UIImage` instance.
-    public let image: UIImage
+    public var image: UIImage {
+        source.getImage(font)
+    }
+    
+    let source: Source
 
     /// Initializes an `Image` component with the name of an image asset.
     /// - Parameter imageName: The name of the image asset to load.
     /// - Note: In DEBUG mode, if the image is not found, an assertion failure is triggered.
     public init(_ imageName: String) {
-#if DEBUG
+        #if DEBUG
         if let image = UIImage(named: imageName) {
             self.init(image)
         } else {
@@ -19,10 +61,9 @@ public struct Image: Component {
             assertionFailure(error)
             self.init(UIImage())
         }
-#else
+        #else
         self.init(UIImage(named: imageName) ?? UIImage())
-#endif
-        
+        #endif
     }
 
     /// Initializes an `Image` component with an `ImageResource`.
@@ -38,31 +79,22 @@ public struct Image: Component {
     ///   - configuration: The configuration to use for the system image.
     /// - Note: In DEBUG mode, if the system image is not found, an assertion failure is triggered.
     public init(systemName: String, withConfiguration configuration: UIImage.Configuration? = nil) {
-#if DEBUG
-        if let systemImage = UIImage(systemName: systemName, withConfiguration: configuration) {
-            self.init(systemImage)
-        } else {
-            let error = "Image should be initialized with a valid system image name. System image named \(systemName) not found."
-            assertionFailure(error)
-            self.init(UIImage())
-        }
-#else
-        self.init(UIImage(systemName: systemName, withConfiguration: configuration) ?? UIImage())
-#endif
-        
+        self.source = .systemImage(systemName: systemName, configuration: configuration)
     }
 
     /// Initializes an `Image` component with a `UIImage` instance.
     /// - Parameter image: The `UIImage` instance to use for the component.
     public init(_ image: UIImage) {
-        self.image = image
+        self.source = .custom(image)
     }
 
     /// Calculates the layout for the image within the given constraints and returns an `ImageRenderNode`.
     /// - Parameter constraint: The constraints to use for sizing the image.
     /// - Returns: An `ImageRenderNode` that represents the laid out image.
     public func layout(_ constraint: Constraint) -> ImageRenderNode {
-        ImageRenderNode(image: image, size: image.size.boundWithAspectRatio(to: constraint))
+        ImageRenderNode(image: image,
+                        foregroundColor: foregroundColor,
+                        size: image.size.boundWithAspectRatio(to: constraint))
     }
 }
 
@@ -70,12 +102,17 @@ public struct Image: Component {
 public struct ImageRenderNode: RenderNode {
     /// The image to be rendered.
     public let image: UIImage
+    /// The foregroundColor to render the tintColor
+    public let foregroundColor: UIColor?
     /// The size to render the image.
     public let size: CGSize
-    
+
     /// Updates the given image view with the render node's image.
     /// - Parameter view: The image view to update.
     public func updateView(_ view: UIImageView) {
         view.image = image
+        if let foregroundColor {
+            view.tintColor = foregroundColor
+        }
     }
 }

--- a/Sources/UIComponent/Components/View/Text.swift
+++ b/Sources/UIComponent/Components/View/Text.swift
@@ -21,6 +21,8 @@ public enum TextContent {
 public struct Text: Component {
     /// Environment-injected font used when rendering plain strings.
     @Environment(\.font) var font
+    /// The foreground color to use when displaying this text
+    @Environment(\.foregroundColor) var foregroundColor
     /// The content of the text, which can be a plain string or an attributed string.
     public let content: TextContent
     /// The maximum number of lines to display the text. 0 means no limit.
@@ -104,7 +106,11 @@ public struct Text: Component {
         let attributedString: NSAttributedString
         switch content {
         case .string(let string):
-            attributedString = NSAttributedString(string: string, attributes: [.font: font])
+            var attributes: [NSAttributedString.Key : Any] = [.font: font]
+            if let foregroundColor {
+                attributes[.foregroundColor] = foregroundColor
+            }
+            attributedString = NSAttributedString(string: string, attributes: attributes)
         case .attributedString(let string):
             attributedString = string
         }

--- a/Sources/UIComponent/Core/Model/Environment/EnvironmentKey/ForegroundColorEnvironmentKey.swift
+++ b/Sources/UIComponent/Core/Model/Environment/EnvironmentKey/ForegroundColorEnvironmentKey.swift
@@ -1,0 +1,39 @@
+//
+//  ForegroundColorEnvironmentKey.swift
+//  UIComponent
+//
+//  Created by y H on 2025/6/25.
+//
+
+import UIKit
+
+/// The key for accessing the default font from the environment.
+public struct ForegroundColorEnvironmentKey: EnvironmentKey {
+    public static var defaultValue: UIColor? { nil }
+}
+
+public extension EnvironmentValues {
+    /// The foregroundColor value in the environment.
+    var foregroundColor: UIColor? {
+        get {
+            self[ForegroundColorEnvironmentKey.self]
+        } set {
+            self[ForegroundColorEnvironmentKey.self] = newValue
+        }
+    }
+}
+
+public extension Component {
+    /// Sets the color of the foreground elements displayed by this view.
+    ///
+    /// - Parameter color: The foreground color to use when displaying this
+    ///   view. Pass `nil` to remove any custom foreground color and to allow
+    ///   the system or the container to provide its own foreground color.
+    ///   If a container-specific override doesn't exist, the system uses
+    ///   the primary color.
+    ///
+    /// - Returns: An environment component with the new foregroundColor value.
+    func foregroundColor(_ color: UIColor?) -> EnvironmentComponent<UIColor?, Self> {
+        environment(\.foregroundColor, value: color)
+    }
+}


### PR DESCRIPTION
Introduces a ForegroundColorEnvironmentKey and environment value for foreground color, enabling components like Text and Image to inherit and use a foreground color from the environment. Adds a new Label component and example demonstrating environment usage. Updates Image and Text components to respect the environment's foreground color, and adds an Environment Example to the sample app.