### PR TITLE
Add foregroundColor environment support to components

### DIFF
--- a/Sources/UIComponent/Components/View/Image.swift
+++ b/Sources/UIComponent/Components/View/Image.swift
@@ -4,14 +4,24 @@ import UIKit
 
 /// An image component that renders an UIImageView
 public struct Image: Component {
-    /// The underlying `UIImage` instance.
-    public let image: UIImage
+    enum Source {
+        case image(UIImage)
+        case systemImage(systemName: String, configuration: UIImage.Configuration?)
+    }
+
+    /// The foreground color to use when displaying this image tint color
+    @Environment(\.foregroundColor) var foregroundColor
+
+    /// The font to use when displaying this systemImage font
+    @Environment(\.font) var font
+    
+    let source: Source
 
     /// Initializes an `Image` component with the name of an image asset.
     /// - Parameter imageName: The name of the image asset to load.
     /// - Note: In DEBUG mode, if the image is not found, an assertion failure is triggered.
     public init(_ imageName: String) {
-#if DEBUG
+        #if DEBUG
         if let image = UIImage(named: imageName) {
             self.init(image)
         } else {
@@ -19,17 +29,16 @@ public struct Image: Component {
             assertionFailure(error)
             self.init(UIImage())
         }
-#else
+        #else
         self.init(UIImage(named: imageName) ?? UIImage())
-#endif
-        
+        #endif
     }
 
     /// Initializes an `Image` component with an `ImageResource`.
     /// - Parameter resource: The `ImageResource` to load the image from.
     @available(iOS 17.0, *)
     public init(_ resource: ImageResource) {
-        self.init(UIImage(resource: resource))
+        self.source = .image(UIImage(resource: resource))
     }
 
     /// Initializes an `Image` component with the name of a system image (SFSymbol).
@@ -38,31 +47,47 @@ public struct Image: Component {
     ///   - configuration: The configuration to use for the system image.
     /// - Note: In DEBUG mode, if the system image is not found, an assertion failure is triggered.
     public init(systemName: String, withConfiguration configuration: UIImage.Configuration? = nil) {
-#if DEBUG
-        if let systemImage = UIImage(systemName: systemName, withConfiguration: configuration) {
-            self.init(systemImage)
-        } else {
-            let error = "Image should be initialized with a valid system image name. System image named \(systemName) not found."
-            assertionFailure(error)
-            self.init(UIImage())
-        }
-#else
-        self.init(UIImage(systemName: systemName, withConfiguration: configuration) ?? UIImage())
-#endif
-        
+        self.source = .systemImage(systemName: systemName, configuration: configuration)
     }
 
     /// Initializes an `Image` component with a `UIImage` instance.
     /// - Parameter image: The `UIImage` instance to use for the component.
     public init(_ image: UIImage) {
-        self.image = image
+        self.source = .image(image)
     }
 
     /// Calculates the layout for the image within the given constraints and returns an `ImageRenderNode`.
     /// - Parameter constraint: The constraints to use for sizing the image.
     /// - Returns: An `ImageRenderNode` that represents the laid out image.
     public func layout(_ constraint: Constraint) -> ImageRenderNode {
-        ImageRenderNode(image: image, size: image.size.boundWithAspectRatio(to: constraint))
+        var image: UIImage {
+            switch source {
+            case .image(let uIImage): return uIImage
+            case .systemImage(let systemName, let configuration):
+                let configuration: UIImage.Configuration? =
+                if let font {
+                    if let configuration {
+                        configuration.applying(UIImage.SymbolConfiguration(font: font))
+                    } else {
+                        UIImage.SymbolConfiguration(font: font)
+                    }
+                } else { configuration }
+#if DEBUG
+                if let systemImage = UIImage(systemName: systemName, withConfiguration: configuration) {
+                    return systemImage
+                } else {
+                    let error = "Image should be initialized with a valid system image name. System image named \(systemName) not found."
+                    assertionFailure(error)
+                    return UIImage()
+                }
+#else
+            return UIImage(systemName: systemName, withConfiguration: configuration) ?? UIImage()
+#endif
+            }
+        }
+        return ImageRenderNode(image: image,
+                        foregroundColor: foregroundColor,
+                        size: image.size.boundWithAspectRatio(to: constraint))
     }
 }
 
@@ -70,12 +95,17 @@ public struct Image: Component {
 public struct ImageRenderNode: RenderNode {
     /// The image to be rendered.
     public let image: UIImage
+    /// The foregroundColor to render the tintColor
+    public let foregroundColor: UIColor?
     /// The size to render the image.
     public let size: CGSize
-    
+
     /// Updates the given image view with the render node's image.
     /// - Parameter view: The image view to update.
     public func updateView(_ view: UIImageView) {
         view.image = image
+        if let foregroundColor {
+            view.tintColor = foregroundColor
+        }
     }
 }

--- a/Sources/UIComponent/Components/View/Text.swift
+++ b/Sources/UIComponent/Components/View/Text.swift
@@ -62,6 +62,8 @@ public struct Text: Component {
     @Environment(\.font) var font
     /// Environment-injected text color used when rendering plain strings.
     @Environment(\.textColor) var textColor
+    /// The foreground color to use when displaying this text
+    @Environment(\.foregroundColor) var foregroundColor
     /// The content of the text, which can be a plain string or an attributed string.
     public let content: TextContent
     /// The maximum number of lines to display the text. 0 means no limit.
@@ -146,6 +148,7 @@ public struct Text: Component {
         if case .string(let string, _) = content, let envFont = font {
             content = .string(string, envFont)
         }
+        var textColor = textColor ?? foregroundColor
         if Self.useSharedLabelForSizing, Thread.isMainThread {
             // Fastest route, but not thread safe.
             layoutLabel.numberOfLines = numberOfLines

--- a/Sources/UIComponent/Core/Model/Environment/EnvironmentKey/ForegroundColorEnvironmentKey.swift
+++ b/Sources/UIComponent/Core/Model/Environment/EnvironmentKey/ForegroundColorEnvironmentKey.swift
@@ -1,0 +1,39 @@
+//
+//  ForegroundColorEnvironmentKey.swift
+//  UIComponent
+//
+//  Created by y H on 2025/6/25.
+//
+
+import UIKit
+
+/// The key for accessing the default font from the environment.
+public struct ForegroundColorEnvironmentKey: EnvironmentKey {
+    public static var defaultValue: UIColor? { nil }
+}
+
+public extension EnvironmentValues {
+    /// The foregroundColor value in the environment.
+    var foregroundColor: UIColor? {
+        get {
+            self[ForegroundColorEnvironmentKey.self]
+        } set {
+            self[ForegroundColorEnvironmentKey.self] = newValue
+        }
+    }
+}
+
+public extension Component {
+    /// Sets the color of the foreground elements displayed by this view.
+    ///
+    /// - Parameter color: The foreground color to use when displaying this
+    ///   view. Pass `nil` to remove any custom foreground color and to allow
+    ///   the system or the container to provide its own foreground color.
+    ///   If a container-specific override doesn't exist, the system uses
+    ///   the primary color.
+    ///
+    /// - Returns: An environment component with the new foregroundColor value.
+    func foregroundColor(_ color: UIColor?) -> EnvironmentComponent<UIColor?, Self> {
+        environment(\.foregroundColor, value: color)
+    }
+}

--- a/UIComponentExample/Chapters/EnvironmentExamplesView.swift
+++ b/UIComponentExample/Chapters/EnvironmentExamplesView.swift
@@ -95,6 +95,33 @@ class EnvironmentExamplesView: UIView {
                         }
                         .font(.boldSystemFont(ofSize: 18))
                     )
+                    Text("It also applies to Images (System Symbols only).", font: .caption)
+                    #CodeExample(
+                        VStack(spacing: 8) {
+                            Text("Uses environment font (bold 18pt)")
+                            Image(systemName: "alarm")
+                            Text("Uses environment font (bold 18pt)")
+                            Image(systemName: "alarm")
+                            Text("I override with font 14pt", font: .systemFont(ofSize: 14))
+                            Image(systemName: "alarm")
+                                .font(.systemFont(ofSize: 14))
+                        }
+                        .font(.boldSystemFont(ofSize: 18))
+                    )
+                    Text("Usage Tips", font: .caption)
+                    #CodeExample(
+                        VStack(spacing: 8) {
+                            let defalutConfiguration = UIImage.SymbolConfiguration(hierarchicalColor: .systemPink)
+                            Text("Use UIImage.Configuration", font: .systemFont(ofSize: 14))
+                            let configuration = UIImage.SymbolConfiguration(scale: .large)
+                                .applying(defalutConfiguration)
+                            Image(systemName: "alarm", withConfiguration: configuration)
+                                .font(nil)
+                            Text("Use environment value.", font: .systemFont(ofSize: 14))
+                            Image(systemName: "alarm", withConfiguration: defalutConfiguration)
+                        }
+                        .font(.systemFont(ofSize: 22))
+                    )
                 }
             }
             
@@ -125,6 +152,35 @@ class EnvironmentExamplesView: UIView {
                         }
                         .font(.boldSystemFont(ofSize: 20))
                         .textColor(.systemRed)
+                    )
+                }
+            }
+            
+            // MARK: - ForegroundColor Color Environment
+            
+            VStack(spacing: 10) {
+                Text("foreground color environment", font: .subtitle)
+                Text("Similar to Text color, you can also add a default tint color to Image. However, it's important to note that the priority order of text color in Text is textColor > foregroundColor.", font: .body).textColor(.secondaryLabel)
+                
+                VStack(spacing: 10) {
+                    Text("Achieve a consistent style using foregroundColor and font.", font: .caption)
+                    #CodeExample(
+                        HStack(spacing: 8) {
+                            Label("Like", systemImage: "heart")
+                                .labelBackground()
+                                .foregroundColor(.systemPink)
+                            Label("Success", systemImage: "checkmark")
+                                .labelBackground()
+                                .foregroundColor(.systemGreen)
+                            Label("Retry", systemImage: "arrow.trianglehead.clockwise.rotate.90")
+                                .labelBackground()
+                                .foregroundColor(.systemBlue)
+                            Label("Different text colors", systemImage: "scribble")
+                                .labelBackground()
+                                .foregroundColor(.systemIndigo)
+                                .textColor(.systemPurple)
+                        }
+                        .font(.systemFont(ofSize: 16, weight: .medium))
                     )
                 }
             }

--- a/UIComponentExample/Chapters/EnvironmentExamplesView.swift
+++ b/UIComponentExample/Chapters/EnvironmentExamplesView.swift
@@ -159,7 +159,7 @@ class EnvironmentExamplesView: UIView {
             // MARK: - ForegroundColor Color Environment
             
             VStack(spacing: 10) {
-                Text("foreground color environment", font: .subtitle)
+                Text("Foreground color environment", font: .subtitle)
                 Text("Similar to Text color, you can also add a default tint color to Image. However, it's important to note that the priority order of text color in Text is textColor > foregroundColor.", font: .body).textColor(.secondaryLabel)
                 
                 VStack(spacing: 10) {

--- a/UIComponentExample/Others/Utilities/Label.swift
+++ b/UIComponentExample/Others/Utilities/Label.swift
@@ -1,0 +1,208 @@
+//  Created by y H on 2025/6/25.
+//  Copyright © 2025 wwdc14yh. All rights reserved.
+
+import UIComponent
+
+public protocol LabelStyle {
+    typealias Configuration = Label.StyleConfiguration
+    associatedtype C: Component
+
+    func makeBody(configuration: Self.Configuration) -> Self.C
+}
+
+public struct DefaultLabelStyle: LabelStyle {
+    public func makeBody(configuration: Configuration) -> some Component {
+        HStack(spacing: 5, alignItems: .center) {
+            configuration.icon
+            configuration.title
+        }
+    }
+}
+
+public extension LabelStyle where Self == DefaultLabelStyle {
+    static var automatic: DefaultLabelStyle {
+        DefaultLabelStyle()
+    }
+}
+
+public struct IconOnlyLabelStyle: LabelStyle {
+    public func makeBody(configuration: Configuration) -> some Component {
+        configuration.icon
+            .eraseToAnyComponent()
+    }
+}
+
+public extension LabelStyle where Self == IconOnlyLabelStyle {
+    static var iconOnly: IconOnlyLabelStyle {
+        IconOnlyLabelStyle()
+    }
+}
+
+public struct TitleOnlyLabelStyle: LabelStyle {
+    public func makeBody(configuration: Configuration) -> some Component {
+        configuration.title
+            .eraseToAnyComponent()
+    }
+}
+
+public struct TitleAndIconLabelStyle: LabelStyle {
+    public enum Layout {
+        case vertical, horizontal
+
+        func makeBody(spacing: CGFloat, alignment: Alignment, @ComponentArrayBuilder content: () -> [any Component]) -> some Component {
+            switch self {
+            case .vertical:
+                VStack(spacing: spacing, alignItems: alignment._tranformCrossAxisAlignment, content)
+                    .eraseToAnyComponent()
+            case .horizontal:
+                HStack(spacing: spacing, alignItems: alignment._tranformCrossAxisAlignment, content)
+                    .eraseToAnyComponent()
+            }
+        }
+    }
+
+    public enum Alignment {
+        case left, center, right
+
+        var _tranformCrossAxisAlignment: CrossAxisAlignment {
+            switch self {
+            case .left: .start
+            case .center: .center
+            case .right: .end
+            }
+        }
+    }
+
+    let layout: Layout
+    let alignment: Alignment
+    let isReversal: Bool
+    let spacing: CGFloat
+
+    public func makeBody(configuration: Configuration) -> some Component {
+        layout.makeBody(spacing: spacing, alignment: alignment) {
+            let components = [configuration.icon, configuration.title]
+            if isReversal {
+                components.reversed()
+            } else {
+                components
+            }
+        }
+    }
+}
+
+public extension LabelStyle where Self == TitleAndIconLabelStyle {
+    static var titleAndIcon: TitleAndIconLabelStyle {
+        titleAndIcon(layout: .horizontal, alignment: .center, isReversal: false, spacing: 5)
+    }
+
+    static func titleAndIcon(layout: TitleAndIconLabelStyle.Layout, alignment: TitleAndIconLabelStyle.Alignment, isReversal: Bool, spacing: CGFloat) -> TitleAndIconLabelStyle {
+        TitleAndIconLabelStyle(layout: layout, alignment: alignment, isReversal: isReversal, spacing: spacing)
+    }
+}
+
+public extension LabelStyle where Self == TitleOnlyLabelStyle {
+    static var titleOnly: TitleOnlyLabelStyle {
+        TitleOnlyLabelStyle()
+    }
+}
+
+public extension Label {
+    struct StyleConfiguration {
+        public let title: any Component
+        public let icon: any Component
+    }
+}
+
+public struct LabelStyleEnvironmentKey: EnvironmentKey {
+    public static var defaultValue: any LabelStyle { .automatic }
+}
+
+public extension EnvironmentValues {
+    var labelStyle: any LabelStyle {
+        get {
+            self[LabelStyleEnvironmentKey.self]
+        } set {
+            self[LabelStyleEnvironmentKey.self] = newValue
+        }
+    }
+}
+
+public extension Component {
+    func labelStyle(_ style: any LabelStyle) -> EnvironmentComponent<any LabelStyle, Self> {
+        environment(\.labelStyle, value: style)
+    }
+}
+
+public struct Label: ComponentBuilder {
+    @Environment(\.labelStyle)
+    var labelStyle
+
+    let title: any Component
+    let icon: any Component
+
+    public init(title: () -> any Component, icon: () -> any Component) {
+        self.title = title()
+        self.icon = icon()
+    }
+
+    public init(_ titleString: String, systemImage name: String, withConfiguration configuration: UIImage.Configuration? = nil) {
+        self.init {
+            Text(titleString)
+        } icon: {
+            Image(systemName: name, withConfiguration: configuration)
+        }
+    }
+
+    public init(_ titleString: String, image name: String) {
+        self.init {
+            Text(titleString)
+        } icon: {
+            Image(name)
+        }
+    }
+
+    public func build() -> some Component {
+        labelStyle.makeBody(configuration: StyleConfiguration(title: title,
+                                                              icon: icon))
+            .eraseToAnyComponent()
+    }
+}
+
+struct LabelBackground: Component {
+    @Environment(\.foregroundColor)
+    var foregroundColor
+
+    let content: any Component
+    let cornerRadius: CGFloat
+    let inset: UIEdgeInsets
+
+    init(content: any Component, cornerRadius: CGFloat = 10, inset: UIEdgeInsets = .init(top: 10, left: 10, bottom: 10, right: 10)) {
+        self.content = content
+        self.cornerRadius = cornerRadius
+        self.inset = inset
+    }
+
+    public func layout(_ constraint: Constraint) -> some RenderNode {
+        let contentRenderNode = content
+            .eraseToAnyComponent()
+            .inset(inset)
+            .backgroundColor(foregroundColor?.withAlphaComponent(0.1))
+            .cornerRadius(10)
+            .cornerCurve(.continuous)
+            .layout(constraint)
+        return contentRenderNode
+    }
+}
+
+struct LabelBackgroundStyle {
+    let color: UIColor
+    let inset: UIEdgeInsets
+
+    static func background(color: UIColor, edgeInsets: UIEdgeInsets = .init(top: 10, left: 10, bottom: 10, right: 10)) -> Self { .init(color: color, inset: edgeInsets) }
+}
+
+extension Component {
+    func labelBackground(_ cornerRadius: CGFloat = 10, inset: UIEdgeInsets = .init(top: 10, left: 10, bottom: 10, right: 10)) -> some Component {
+        LabelBackground(content: self, cornerRadius: cornerRadius, inset: inset)
+    }
+}


### PR DESCRIPTION
Introduces ForegroundColorEnvironmentKey to enable environment-based foreground color for components. Updates Image and Text components to use foregroundColor from the environment, allowing consistent tinting and styling. Adds usage examples and a new Label utility to demonstrate foregroundColor and font environment integration.
<img width="554" height="701" alt="iShot_2025-11-09_00 33 48" src="https://github.com/user-attachments/assets/2c5c9c3a-dda1-4a47-9dda-358a79c55686" />
<img width="646" height="412" alt="image" src="https://github.com/user-attachments/assets/3560815a-7afd-46bb-a3c5-6fa6594e5f74" />
