### PR TITLE
Support GlassTappableView glass effect across platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Select latest Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Show Xcode version
+        run: xcodebuild -version
       - name: Test Swift package on iOS Simulator
         run: |
           tmpdir="$(mktemp -d)"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,13 @@ jobs:
     runs-on: macos-15
 
     steps:
-    - name: List Xcode installations
-      run: sudo ls -1 /Applications | grep "Xcode"
-    - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
     - uses: actions/checkout@v3
+    - name: Select latest Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Show Xcode version
+      run: xcodebuild -version
     - name: Set up Pages
       uses: actions/configure-pages@v4
     - name: Generate Docs

--- a/Sources/UIComponent/Components/View/GlassTappableView.swift
+++ b/Sources/UIComponent/Components/View/GlassTappableView.swift
@@ -194,16 +194,16 @@ open class GlassTappableView: UIVisualEffectView {
     }
 
     public static func defaultEffect() -> UIVisualEffect {
-        #if os(iOS)
-        if #available(iOS 26.0, *) {
+        if #available(iOS 26.0, tvOS 26.0, macCatalyst 26.0, *) {
             let effect = UIGlassEffect(style: .regular)
             effect.isInteractive = true
             return effect
-        } else {
-            return UIBlurEffect(style: .systemMaterial)
         }
-        #else
+
+        #if os(tvOS)
         return UIBlurEffect(style: .regular)
+        #else
+        return UIBlurEffect(style: .systemMaterial)
         #endif
     }
 


### PR DESCRIPTION
## Summary
- Use interactive UIGlassEffect on iOS 26, tvOS 26, and Mac Catalyst 26+
- Keep tvOS fallback on regular blur because systemMaterial is unavailable there
- Keep system material fallback for older iOS and Catalyst

## Verification
- git diff --check
- xcodebuild -project UIComponentExample.xcodeproj -scheme UIComponent -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build
- xcodebuild -project UIComponentExample.xcodeproj -scheme UIComponent -sdk appletvsimulator -destination 'generic/platform=tvOS Simulator' build
- xcodebuild -project UIComponentExample.xcodeproj -scheme UIComponent -destination 'generic/platform=macOS,variant=Mac Catalyst' build