### PR TITLE
Make PrimaryMenu subclassable

### DIFF
--- a/Sources/UIComponent/Components/View/PrimaryMenu.swift
+++ b/Sources/UIComponent/Components/View/PrimaryMenu.swift
@@ -30,7 +30,7 @@ public typealias PrimaryMenuConfiguration = PrimaryMenuConfig
 
 /// A UIControl subclass that displays a context menu when tapped.
 @available(iOS 14.0, *)
-public class PrimaryMenu: UIControl {
+open class PrimaryMenu: UIControl {
     /// Indicates whether any `PrimaryMenu` is currently showing a menu.
     public static fileprivate(set) var isShowingMenu = false
 
@@ -82,7 +82,7 @@ public class PrimaryMenu: UIControl {
     }
 
     /// A flag indicating whether the control is currently in a pressed state.
-    public private(set) var isPressed: Bool = false {
+    open var isPressed: Bool = false {
         didSet {
             guard isPressed != oldValue else { return }
             (config ?? .default).onHighlightChanged?(self, isPressed)
@@ -91,7 +91,7 @@ public class PrimaryMenu: UIControl {
 
     /// Initializes a new instance of the `PrimaryMenu`.
     /// - Parameter frame: The frame rectangle for the control, measured in points.
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         showsMenuAsPrimaryAction = true
         isContextMenuInteractionEnabled = true
@@ -99,30 +99,30 @@ public class PrimaryMenu: UIControl {
         addInteraction(UIPointerInteraction(delegate: self))
     }
 
-    required init?(coder: NSCoder) {
+    required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Touch Handling
 
-    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         isPressed = true
     }
 
-    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+    open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
         isPressed = false
     }
 
-    public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+    open override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesCancelled(touches, with: event)
         isPressed = false
     }
 
     // MARK: - UIContextMenuInteractionDelegate
 
-    public override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
+    open override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         (config ?? .default).didTap?(self)
         let menuConfiguration = UIContextMenuConfiguration(actionProvider: { [menuBuilder, weak self] suggested in
             guard let self else { return UIMenu() }
@@ -134,12 +134,12 @@ public class PrimaryMenu: UIControl {
         return menuConfiguration
     }
 
-    public override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+    open override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willDisplayMenuFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
         isShowingMenu = true
         PrimaryMenu.isShowingMenu = true
     }
 
-    public override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willEndFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+    open override func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willEndFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
         isShowingMenu = false
         PrimaryMenu.isShowingMenu = false
     }


### PR DESCRIPTION
## Summary\n- Make PrimaryMenu open so downstream modules can subclass it.\n- Open the touch and context-menu override points to match TappableView's subclassing surface.\n- Expose the frame initializer publicly for external subclass construction.\n\n## Testing\n- xcodebuild -project UIComponentExample.xcodeproj -scheme UIComponent -destination 'generic/platform=iOS Simulator' build