### PR TITLE
[codex] Make tappable highlight immediate

### DIFF
--- a/Sources/UIComponent/Components/View/GlassTappableView.swift
+++ b/Sources/UIComponent/Components/View/GlassTappableView.swift
@@ -34,6 +34,17 @@ open class GlassTappableView: UIVisualEffectView {
     /// A gesture recognizer for detecting single taps on the GlassTappableView.
     public private(set) lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
 
+    /// A gesture recognizer for immediate press/highlight state.
+    public private(set) lazy var highlightGestureRecognizer: UILongPressGestureRecognizer = {
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(didChangeHighlight))
+        gesture.minimumPressDuration = 0
+        gesture.cancelsTouchesInView = false
+        gesture.delaysTouchesBegan = false
+        gesture.delaysTouchesEnded = false
+        gesture.delegate = self
+        return gesture
+    }()
+
     /// A gesture recognizer for detecting double taps on the GlassTappableView.
     public private(set) lazy var doubleTapGestureRecognizer: UITapGestureRecognizer = {
         let gesture = UITapGestureRecognizer(target: self, action: #selector(didDoubleTap))
@@ -266,11 +277,32 @@ open class GlassTappableView: UIVisualEffectView {
     private func configure() {
         isUserInteractionEnabled = true
         accessibilityTraits = .button
+        addGestureRecognizer(highlightGestureRecognizer)
         #if !os(tvOS)
         if #available(iOS 13.4, *) {
             addInteraction(UIPointerInteraction(delegate: self))
         }
         #endif
+    }
+
+    @objc open func didChangeHighlight() {
+        switch highlightGestureRecognizer.state {
+        case .began, .changed:
+            isHighlighted = bounds.contains(highlightGestureRecognizer.location(in: self))
+        case .ended, .cancelled, .failed:
+            isHighlighted = false
+        default:
+            break
+        }
+    }
+}
+
+extension GlassTappableView: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        gestureRecognizer === highlightGestureRecognizer || otherGestureRecognizer === highlightGestureRecognizer
     }
 }
 

--- a/Sources/UIComponent/Components/View/TappableView.swift
+++ b/Sources/UIComponent/Components/View/TappableView.swift
@@ -79,6 +79,17 @@ open class TappableView: UIView {
 
     /// A gesture recognizer for detecting single taps on the TappableView.
     public private(set) lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTap))
+
+    /// A gesture recognizer for immediate press/highlight state.
+    public private(set) lazy var highlightGestureRecognizer: UILongPressGestureRecognizer = {
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(didChangeHighlight))
+        gesture.minimumPressDuration = 0
+        gesture.cancelsTouchesInView = false
+        gesture.delaysTouchesBegan = false
+        gesture.delaysTouchesEnded = false
+        gesture.delegate = self
+        return gesture
+    }()
     
     /// A gesture recognizer for detecting double taps on the TappableView.
     public private(set) lazy var doubleTapGestureRecognizer: UITapGestureRecognizer = {
@@ -229,6 +240,7 @@ open class TappableView: UIView {
     public override init(frame: CGRect) {
         super.init(frame: frame)
         accessibilityTraits = .button
+        addGestureRecognizer(highlightGestureRecognizer)
     #if !os(tvOS)
         if #available(iOS 13.4, *) {
             addInteraction(UIPointerInteraction(delegate: self))
@@ -294,6 +306,26 @@ open class TappableView: UIView {
     /// Called when a long press is recognized.
     @objc open func didLongPress() {
         onLongPress?(self, longPressGestureRecognizer)
+    }
+
+    @objc open func didChangeHighlight() {
+        switch highlightGestureRecognizer.state {
+        case .began, .changed:
+            isHighlighted = bounds.contains(highlightGestureRecognizer.location(in: self))
+        case .ended, .cancelled, .failed:
+            isHighlighted = false
+        default:
+            break
+        }
+    }
+}
+
+extension TappableView: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        gestureRecognizer === highlightGestureRecognizer || otherGestureRecognizer === highlightGestureRecognizer
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a dedicated zero-duration highlight gesture recognizer to both `TappableView` and `GlassTappableView` so `onHighlightChanged` can respond immediately on touch down instead of relying only on the wrapper view's `touchesBegan` path.

## Why

The existing highlight state is driven from `touchesBegan`/`touchesEnded` on the tappable wrapper view. In component hierarchies where the hit-test lands on rendered child views while tap recognizers are also installed, that touch path can be delayed enough to make press feedback feel late.

## Details

- Adds `highlightGestureRecognizer` to `TappableView` and `GlassTappableView`.
- Uses `minimumPressDuration = 0` for immediate press detection.
- Keeps it non-cancelling and non-delaying so normal tap, long-press, and child touch handling continue to work.
- Allows simultaneous recognition for the highlight recognizer.
- Tracks whether the touch is still inside bounds during movement.

## Validation

- `git diff --check`
- `xcodebuild -scheme UIComponent -destination 'generic/platform=iOS' build`

Note: `swift test` was attempted, but this package imports UIKit and does not build as a macOS SwiftPM test target (`no such module 'UIKit'`).