### PR TITLE
Add separate Waterfall spacing controls

### DIFF
--- a/Sources/UIComponent/Components/Layout/Other/Waterfall.swift
+++ b/Sources/UIComponent/Components/Layout/Other/Waterfall.swift
@@ -4,27 +4,17 @@
 /// A waterfall layout is a type of layout that arranges items in multiple columns with varying item heights.
 /// - Parameters:
 ///   - columns: The number of columns in the layout.
-///   - spacing: The spacing between columns and items in the layout.
 ///   - columnSpacing: The spacing between columns in the layout.
 ///   - interItemSpacing: The spacing between items within each column.
 ///   - children: The components that will be laid out according to the waterfall layout.
 public protocol WaterfallLayoutProtocol: BaseLayoutProtocol {
     var columns: Int { get }
-    var spacing: CGFloat { get }
     var columnSpacing: CGFloat { get }
     var interItemSpacing: CGFloat { get }
     var children: [any Component] { get }
 }
 
 extension WaterfallLayoutProtocol {
-    public var columnSpacing: CGFloat {
-        spacing
-    }
-
-    public var interItemSpacing: CGFloat {
-        spacing
-    }
-
     public func layout(_ constraint: Constraint) -> R {
         var renderNodes: [any RenderNode] = []
         var positions: [CGPoint] = []

--- a/Sources/UIComponent/Components/Layout/Other/Waterfall.swift
+++ b/Sources/UIComponent/Components/Layout/Other/Waterfall.swift
@@ -4,20 +4,32 @@
 /// A waterfall layout is a type of layout that arranges items in multiple columns with varying item heights.
 /// - Parameters:
 ///   - columns: The number of columns in the layout.
-///   - spacing: The spacing between items in the layout.
+///   - spacing: The spacing between columns and items in the layout.
+///   - columnSpacing: The spacing between columns in the layout.
+///   - interItemSpacing: The spacing between items within each column.
 ///   - children: The components that will be laid out according to the waterfall layout.
 public protocol WaterfallLayoutProtocol: BaseLayoutProtocol {
     var columns: Int { get }
     var spacing: CGFloat { get }
+    var columnSpacing: CGFloat { get }
+    var interItemSpacing: CGFloat { get }
     var children: [any Component] { get }
 }
 
 extension WaterfallLayoutProtocol {
+    public var columnSpacing: CGFloat {
+        spacing
+    }
+
+    public var interItemSpacing: CGFloat {
+        spacing
+    }
+
     public func layout(_ constraint: Constraint) -> R {
         var renderNodes: [any RenderNode] = []
         var positions: [CGPoint] = []
 
-        let columnWidth = (cross(constraint.maxSize) - CGFloat(columns - 1) * spacing) / CGFloat(columns)
+        let columnWidth = (cross(constraint.maxSize) - CGFloat(columns - 1) * columnSpacing) / CGFloat(columns)
         var columnHeight = [CGFloat](repeating: 0, count: columns)
 
         func getMinColomn() -> (Int, CGFloat) {
@@ -36,13 +48,13 @@ extension WaterfallLayoutProtocol {
                 )
             )
             let (columnIndex, offsetY) = getMinColomn()
-            columnHeight[columnIndex] += main(renderNode.size) + spacing
+            columnHeight[columnIndex] += main(renderNode.size) + interItemSpacing
             renderNodes.append(renderNode)
-            positions.append(point(main: offsetY, cross: CGFloat(columnIndex) * (columnWidth + spacing)))
+            positions.append(point(main: offsetY, cross: CGFloat(columnIndex) * (columnWidth + columnSpacing)))
         }
 
         return renderNode(
-            size: size(main: max(0, columnHeight.max()! - spacing), cross: cross(constraint.maxSize)),
+            size: size(main: max(0, columnHeight.max()! - interItemSpacing), cross: cross(constraint.maxSize)),
             children: renderNodes,
             positions: positions
         )
@@ -53,20 +65,43 @@ extension WaterfallLayoutProtocol {
 public struct Waterfall: Component, WaterfallLayoutProtocol, VerticalLayoutProtocol {
     /// The number of columns in the layout.
     public var columns: Int
-    /// The spacing between items in the layout.
-    public var spacing: CGFloat
+    /// The spacing between columns in the layout.
+    public var columnSpacing: CGFloat
+    /// The spacing between items within each column.
+    public var interItemSpacing: CGFloat
+    /// The spacing between columns and items in the layout.
+    public var spacing: CGFloat {
+        get {
+            interItemSpacing
+        }
+        set {
+            columnSpacing = newValue
+            interItemSpacing = newValue
+        }
+    }
     /// The components that will be laid out according to the waterfall layout.
     public var children: [any Component]
 
     /// Initializes a new `Waterfall` layout with the specified number of columns, spacing, and child components.
     /// - Parameters:
     ///   - columns: The number of columns in the layout. Defaults to 2.
-    ///   - spacing: The spacing between items in the layout. Defaults to 0.
+    ///   - columnSpacing: The spacing between columns in the layout. Defaults to 0.
+    ///   - interItemSpacing: The spacing between items within each column. Defaults to 0.
     ///   - children: The components that will be laid out according to the waterfall layout. Defaults to an empty array.
-    public init(columns: Int = 2, spacing: CGFloat = 0, children: [any Component] = []) {
+    public init(columns: Int = 2, columnSpacing: CGFloat = 0, interItemSpacing: CGFloat = 0, children: [any Component] = []) {
         self.columns = columns
-        self.spacing = spacing
+        self.columnSpacing = columnSpacing
+        self.interItemSpacing = interItemSpacing
         self.children = children
+    }
+
+    /// Initializes a new `Waterfall` layout with equal spacing between columns and items.
+    /// - Parameters:
+    ///   - columns: The number of columns in the layout. Defaults to 2.
+    ///   - spacing: The spacing between columns and items in the layout.
+    ///   - children: The components that will be laid out according to the waterfall layout. Defaults to an empty array.
+    public init(columns: Int = 2, spacing: CGFloat, children: [any Component] = []) {
+        self.init(columns: columns, columnSpacing: spacing, interItemSpacing: spacing, children: children)
     }
 }
 
@@ -74,19 +109,42 @@ public struct Waterfall: Component, WaterfallLayoutProtocol, VerticalLayoutProto
 public struct HorizontalWaterfall: Component, WaterfallLayoutProtocol, HorizontalLayoutProtocol {
     /// The number of rows in the layout.
     public var columns: Int
-    /// The spacing between items in the layout.
-    public var spacing: CGFloat
+    /// The spacing between rows in the layout.
+    public var columnSpacing: CGFloat
+    /// The spacing between items within each row.
+    public var interItemSpacing: CGFloat
+    /// The spacing between rows and items in the layout.
+    public var spacing: CGFloat {
+        get {
+            interItemSpacing
+        }
+        set {
+            columnSpacing = newValue
+            interItemSpacing = newValue
+        }
+    }
     /// The components that will be laid out according to the horizontal waterfall layout.
     public var children: [any Component]
     /// Initializes a new `HorizontalWaterfall` layout with the specified number of rows, spacing, and child components.
     /// - Parameters:
     ///   - columns: The number of rows in the layout. Defaults to 2.
-    ///   - spacing: The spacing between items in the layout. Defaults to 0.
+    ///   - columnSpacing: The spacing between rows in the layout. Defaults to 0.
+    ///   - interItemSpacing: The spacing between items within each row. Defaults to 0.
     ///   - children: The components that will be laid out according to the horizontal waterfall layout. Defaults to an empty array.
-    public init(columns: Int = 2, spacing: CGFloat = 0, children: [any Component] = []) {
+    public init(columns: Int = 2, columnSpacing: CGFloat = 0, interItemSpacing: CGFloat = 0, children: [any Component] = []) {
         self.columns = columns
-        self.spacing = spacing
+        self.columnSpacing = columnSpacing
+        self.interItemSpacing = interItemSpacing
         self.children = children
+    }
+
+    /// Initializes a new `HorizontalWaterfall` layout with equal spacing between rows and items.
+    /// - Parameters:
+    ///   - columns: The number of rows in the layout. Defaults to 2.
+    ///   - spacing: The spacing between rows and items in the layout.
+    ///   - children: The components that will be laid out according to the horizontal waterfall layout. Defaults to an empty array.
+    public init(columns: Int = 2, spacing: CGFloat, children: [any Component] = []) {
+        self.init(columns: columns, columnSpacing: spacing, interItemSpacing: spacing, children: children)
     }
 }
 
@@ -95,9 +153,19 @@ extension Waterfall {
     /// This initializer allows for a trailing closure syntax to define the child components using a ``ComponentArrayBuilder``.
     /// - Parameters:
     ///   - columns: The number of columns in the layout. Defaults to 2.
-    ///   - spacing: The spacing between items in the layout. Defaults to 0.
+    ///   - columnSpacing: The spacing between columns in the layout. Defaults to 0.
+    ///   - interItemSpacing: The spacing between items within each column. Defaults to 0.
     ///   - content: A result builder closure that returns an array of components to be laid out in the waterfall layout.
-    public init(columns: Int = 2, spacing: CGFloat = 0, @ComponentArrayBuilder _ content: () -> [any Component]) {
+    public init(columns: Int = 2, columnSpacing: CGFloat = 0, interItemSpacing: CGFloat = 0, @ComponentArrayBuilder _ content: () -> [any Component]) {
+        self.init(columns: columns, columnSpacing: columnSpacing, interItemSpacing: interItemSpacing, children: content())
+    }
+
+    /// Initializes a new ``Waterfall`` layout with equal spacing between columns and items using a result builder.
+    /// - Parameters:
+    ///   - columns: The number of columns in the layout. Defaults to 2.
+    ///   - spacing: The spacing between columns and items in the layout.
+    ///   - content: A result builder closure that returns an array of components to be laid out in the waterfall layout.
+    public init(columns: Int = 2, spacing: CGFloat, @ComponentArrayBuilder _ content: () -> [any Component]) {
         self.init(columns: columns, spacing: spacing, children: content())
     }
 }
@@ -107,9 +175,19 @@ extension HorizontalWaterfall {
     /// This initializer allows for a trailing closure syntax to define the child components using a ``ComponentArrayBuilder``.
     /// - Parameters:
     ///   - columns: The number of rows in the layout. Defaults to 2.
-    ///   - spacing: The spacing between items in the layout. Defaults to 0.
+    ///   - columnSpacing: The spacing between rows in the layout. Defaults to 0.
+    ///   - interItemSpacing: The spacing between items within each row. Defaults to 0.
     ///   - content: A result builder closure that returns an array of components to be laid out in the horizontal waterfall layout.
-    public init(columns: Int = 2, spacing: CGFloat = 0, @ComponentArrayBuilder _ content: () -> [any Component]) {
+    public init(columns: Int = 2, columnSpacing: CGFloat = 0, interItemSpacing: CGFloat = 0, @ComponentArrayBuilder _ content: () -> [any Component]) {
+        self.init(columns: columns, columnSpacing: columnSpacing, interItemSpacing: interItemSpacing, children: content())
+    }
+
+    /// Initializes a new ``HorizontalWaterfall`` layout with equal spacing between rows and items using a result builder.
+    /// - Parameters:
+    ///   - columns: The number of rows in the layout. Defaults to 2.
+    ///   - spacing: The spacing between rows and items in the layout.
+    ///   - content: A result builder closure that returns an array of components to be laid out in the horizontal waterfall layout.
+    public init(columns: Int = 2, spacing: CGFloat, @ComponentArrayBuilder _ content: () -> [any Component]) {
         self.init(columns: columns, spacing: spacing, children: content())
     }
 }

--- a/Tests/UIComponentTests/SizingTest.swift
+++ b/Tests/UIComponentTests/SizingTest.swift
@@ -45,4 +45,46 @@ struct SizingTest {
         #expect(component.layout(Constraint(maxSize: CGSize(width: 1000.0, height: .infinity))).size.width == 1000)
         #expect(component.layout(Constraint(maxSize: CGSize(width: 1000.0, height: .infinity))).children.first!.size.width == 1000)
     }
+
+    @Test func testWaterfallSeparateSpacing() throws {
+        let component = Waterfall(columns: 2, columnSpacing: 10, interItemSpacing: 5) {
+            Space(width: 10, height: 20)
+            Space(width: 10, height: 10)
+            Space(width: 10, height: 15)
+        }
+
+        let renderNode = component.layout(Constraint(maxSize: CGSize(width: 110, height: CGFloat.infinity)))
+        #expect(renderNode.size == CGSize(width: 110, height: 30))
+        #expect(renderNode.children.map { $0.size } == [
+            CGSize(width: 50, height: 20),
+            CGSize(width: 50, height: 10),
+            CGSize(width: 50, height: 15)
+        ])
+        #expect(renderNode.positions == [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 60, y: 0),
+            CGPoint(x: 60, y: 15)
+        ])
+    }
+
+    @Test func testHorizontalWaterfallSeparateSpacing() throws {
+        let component = HorizontalWaterfall(columns: 2, columnSpacing: 10, interItemSpacing: 5) {
+            Space(width: 20, height: 10)
+            Space(width: 10, height: 10)
+            Space(width: 15, height: 10)
+        }
+
+        let renderNode = component.layout(Constraint(maxSize: CGSize(width: CGFloat.infinity, height: 110)))
+        #expect(renderNode.size == CGSize(width: 30, height: 110))
+        #expect(renderNode.children.map { $0.size } == [
+            CGSize(width: 20, height: 50),
+            CGSize(width: 10, height: 50),
+            CGSize(width: 15, height: 50)
+        ])
+        #expect(renderNode.positions == [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 0, y: 60),
+            CGPoint(x: 15, y: 60)
+        ])
+    }
 }


### PR DESCRIPTION
## Summary
- add `columnSpacing` and `interItemSpacing` to `Waterfall` and `HorizontalWaterfall`
- keep `spacing:` as the equal-spacing shorthand
- add layout tests for separate vertical and horizontal waterfall spacing

## Tests
- `xcodebuild test -project UIComponentExample.xcodeproj -scheme UIComponentTests -destination 'platform=iOS Simulator,id=D5B23B47-7D2D-45E3-8A67-A52DBB5C6603'`